### PR TITLE
Alternative for gptCursorAsync

### DIFF
--- a/src/win/Input.cpp
+++ b/src/win/Input.cpp
@@ -24,6 +24,11 @@ namespace memstream::windows {
         this->gafAsyncKeyStateAddr = this->kernel->GetExport("win32kbase.sys", "gafAsyncKeyState");
         this->gptCursorAsync = this->kernel->GetExport("win32kbase.sys", "gptCursorAsync");
 
+        //Somtimes win32kbase screws up. Getting the import from win32kfull.sys is an alternative way
+        if (!this->gptCursorAsync) {
+            this->gptCursorAsync = this->kernel->GetImport("win32kfull.sys", "gptCursorAsync");
+        }
+
         if (!this->gafAsyncKeyStateAddr) {
             // probably windows 11 -- need to pull from win32ksgd.sys
 


### PR DESCRIPTION
Ran into an issue where VMMDLL_ProcessGetProcAddressU and VMMDLL_Map_GetEATU were both failing to get any exports from win32kbase. 
Found an alternative that allowed reading the cursor position from win32kfull pulling it from the Import Table
![image](https://github.com/KeganHollern/MemStream/assets/79125665/4fc95a9f-5736-479e-8b29-16c1b35f57d2)
